### PR TITLE
#94 skipParcels -> skipBytes

### DIFF
--- a/app/src/kernel/Adjuster.test.ts
+++ b/app/src/kernel/Adjuster.test.ts
@@ -15,7 +15,7 @@ describe("adjuster", () => {
 
     test("smoke with one j", () => {
         const result = performDisassemble(`6f f0 5f fe`,
-            {order: InputOrder.BYTE_ORDER_LE, parcelSkip: 0},
+            {order: InputOrder.BYTE_ORDER_LE, bytesSkip: 0},
             {bitDepth: BitDepth.BIT_32}
         ) as DisassembleOutputValid
         expect(result.valid).toEqual("valid")
@@ -27,7 +27,7 @@ describe("adjuster", () => {
         const result = performDisassemble(`
 13 00 00 00
 0b 00 00 00`,
-            {order: InputOrder.BYTE_ORDER_LE, parcelSkip: 0},
+            {order: InputOrder.BYTE_ORDER_LE, bytesSkip: 0},
             {bitDepth: BitDepth.BIT_32}
         ) as DisassembleOutputValid
         expect(result.valid).toEqual("valid")
@@ -39,7 +39,7 @@ describe("adjuster", () => {
         const result = performDisassemble(`
 13 00 00 00
 6f f0 ff ff`,
-            {order: InputOrder.BYTE_ORDER_LE, parcelSkip: 0},
+            {order: InputOrder.BYTE_ORDER_LE, bytesSkip: 0},
             {bitDepth: BitDepth.BIT_32}
         ) as DisassembleOutputValid
         expect(result.valid).toEqual("valid")
@@ -51,7 +51,7 @@ describe("adjuster", () => {
         const result = performDisassemble(`
 6f 00 60 00
 13 00 00 00`,
-            {order: InputOrder.BYTE_ORDER_LE, parcelSkip: 0},
+            {order: InputOrder.BYTE_ORDER_LE, bytesSkip: 0},
             {bitDepth: BitDepth.BIT_32}
         ) as DisassembleOutputValid
         expect(result.valid).toEqual("valid")
@@ -62,7 +62,7 @@ describe("adjuster", () => {
     test("smoke with out jump", () => {
         const result = performDisassemble(`
 e7 00 05 00`,
-            {order: InputOrder.BYTE_ORDER_LE, parcelSkip: 0},
+            {order: InputOrder.BYTE_ORDER_LE, bytesSkip: 0},
             {bitDepth: BitDepth.BIT_32}
         ) as DisassembleOutputValid
         expect(result.valid).toEqual("valid")
@@ -74,7 +74,7 @@ e7 00 05 00`,
         const result = performDisassemble(`
 13 00 00 00
 6f f0 5f fe`,
-            {order: InputOrder.BYTE_ORDER_LE, parcelSkip: 0},
+            {order: InputOrder.BYTE_ORDER_LE, bytesSkip: 0},
             {bitDepth: BitDepth.BIT_32}
         ) as DisassembleOutputValid
         expect(result.valid).toEqual("valid")
@@ -86,7 +86,7 @@ e7 00 05 00`,
         const result = performDisassemble(`
 6f 00 a0 00
 13 00 00 00`,
-            {order: InputOrder.BYTE_ORDER_LE, parcelSkip: 0},
+            {order: InputOrder.BYTE_ORDER_LE, bytesSkip: 0},
             {bitDepth: BitDepth.BIT_32}
         ) as DisassembleOutputValid
         expect(result.valid).toEqual("valid")
@@ -108,7 +108,7 @@ b3 e2 62 00
 6f f0 5f fe
 13 85 02 00
 `,
-            {order: InputOrder.BYTE_ORDER_LE, parcelSkip: 0},
+            {order: InputOrder.BYTE_ORDER_LE, bytesSkip: 0},
             {bitDepth: BitDepth.BIT_32}
         ) as DisassembleOutputValid
         expect(result.valid).toEqual("valid")

--- a/app/src/kernel/InputParser.test.ts
+++ b/app/src/kernel/InputParser.test.ts
@@ -2,7 +2,7 @@ import {InputOrder, inputParser} from "./InputParser";
 
 describe("inputParser", () => {
     test("empty", () => {
-        expect(inputParser("", {order: InputOrder.BYTE_ORDER_LE, parcelSkip: 0})).toEqual({
+        expect(inputParser("", {order: InputOrder.BYTE_ORDER_LE, bytesSkip: 0})).toEqual({
             valid: "valid",
             startAddress: 0,
             bytesConcat: ""
@@ -13,10 +13,10 @@ describe("inputParser", () => {
     test("simple example", () => {
         expect(inputParser("0x0010: 01234567", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         })).toEqual({
             valid: "valid",
-            startAddress: 16,
+            startAddress: 0x10,
             bytesConcat: ["10000000", "11000100", "10100010", "11100110"].join("")
         });
     });
@@ -24,10 +24,10 @@ describe("inputParser", () => {
     test("simple example with LE", () => {
         expect(inputParser("0x0010: 01234567", {
             order: InputOrder.BYTE_ORDER_LE,
-            parcelSkip: 0
+            bytesSkip: 0
         })).toEqual({
             valid: "valid",
-            startAddress: 16,
+            startAddress: 0x10,
             bytesConcat: ["11100110", "10100010", "11000100", "10000000"].join("")
         });
     });
@@ -35,10 +35,10 @@ describe("inputParser", () => {
     test("simple example2", () => {
         expect(inputParser("0x0014: 09abcdef", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         })).toEqual({
             valid: "valid",
-            startAddress: 20,
+            startAddress: 0x14,
             bytesConcat: ["10010000", "11010101", "10110011", "11110111"].join("")
         });
     });
@@ -46,10 +46,10 @@ describe("inputParser", () => {
     test("simple example2 with upper case", () => {
         expect(inputParser("0x0014: 09ABCDEF", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         })).toEqual({
             valid: "valid",
-            startAddress: 20,
+            startAddress: 0x14,
             bytesConcat: ["10010000", "11010101", "10110011", "11110111"].join("")
         });
     });
@@ -57,10 +57,10 @@ describe("inputParser", () => {
     test("simple example3", () => {
         expect(inputParser("0x0010: 01234567\n0x0014: 09abcdef", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         })).toEqual({
             valid: "valid",
-            startAddress: 16,
+            startAddress: 0x10,
             bytesConcat: [
                 "10000000", "11000100", "10100010", "11100110",
                 "10010000", "11010101", "10110011", "11110111"
@@ -71,10 +71,10 @@ describe("inputParser", () => {
     test("simple example4", () => {
         expect(inputParser("0x0010: 0a1b2c3d 4e5f", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         })).toEqual({
             valid: "valid",
-            startAddress: 16,
+            startAddress: 0x10,
             bytesConcat: [
                 "01010000", "11011000", "00110100", "10111100",
                 "01110010", "11111010"
@@ -85,10 +85,10 @@ describe("inputParser", () => {
     test("simple example4 with LE", () => {
         expect(inputParser("0x0010: 0a1b2c3d 4e5f", {
             order: InputOrder.BYTE_ORDER_LE,
-            parcelSkip: 0
+            bytesSkip: 0
         })).toEqual({
             valid: "valid",
-            startAddress: 16,
+            startAddress: 0x10,
             bytesConcat: [
                 "10111100", "00110100", "11011000", "01010000",
                 "11111010", "01110010"
@@ -99,21 +99,32 @@ describe("inputParser", () => {
     test("without 0x", () => {
         expect(inputParser("0010: 09abcdef", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         })).toEqual({
             valid: "valid",
-            startAddress: 16,
+            startAddress: 0x10,
             bytesConcat: ["10010000", "11010101", "10110011", "11110111"].join("")
+        });
+    });
+
+    test("byte skip", () => {
+        expect(inputParser("0x0014: 09abcdef", {
+            order: InputOrder.BYTE_ORDER_BE,
+            bytesSkip: 1
+        })).toEqual({
+            valid: "valid",
+            startAddress: 0x15,
+            bytesConcat: ["11010101", "10110011", "11110111"].join("")
         });
     });
 
     test("parcel skip", () => {
         expect(inputParser("0x0014: 09abcdef", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 1
+            bytesSkip: 2
         })).toEqual({
             valid: "valid",
-            startAddress: 21,
+            startAddress: 0x16,
             bytesConcat: ["10110011", "11110111"].join("")
         });
     });
@@ -121,10 +132,10 @@ describe("inputParser", () => {
     test("parcel skip with LE", () => {
         expect(inputParser("0x0014: 09abcdef", {
             order: InputOrder.BYTE_ORDER_LE,
-            parcelSkip: 1
+            bytesSkip: 2
         })).toEqual({
             valid: "valid",
-            startAddress: 21,
+            startAddress: 0x16,
             bytesConcat: ["11010101", "10010000"].join("")
         });
     });
@@ -132,10 +143,10 @@ describe("inputParser", () => {
     test("2 parcel skip", () => {
         expect(inputParser("0x0014: 09abcdef", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 2
+            bytesSkip: 4
         })).toEqual({
             valid: "valid",
-            startAddress: 22,
+            startAddress: 0x18,
             bytesConcat: ""
         });
     });
@@ -143,10 +154,10 @@ describe("inputParser", () => {
     test("2 parcel skip with LE", () => {
         expect(inputParser("0x0014: 09abcdef", {
             order: InputOrder.BYTE_ORDER_LE,
-            parcelSkip: 2
+            bytesSkip: 4
         })).toEqual({
             valid: "valid",
-            startAddress: 22,
+            startAddress: 0x18,
             bytesConcat: ""
         });
     });
@@ -155,21 +166,21 @@ describe("inputParser", () => {
     test("bad input", () => {
         expect(inputParser("0x0014: a", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         }).valid).toEqual("invalid");
     });
 
     test("bad input2", () => {
         expect(inputParser(": 09abcdef", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         }).valid).toEqual("invalid");
     });
 
     test("bad input: bad addresses", () => {
         expect(inputParser("0x0010: 09abcdef 0x0012: 09abcdef", {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         }).valid).toEqual("invalid");
     });
 
@@ -181,7 +192,7 @@ describe("inputParser", () => {
 0x0000003f91b1a02e:   20 69 9c 60 b3 04 f5 40 97 60 e4 ff e7 80 20 6a
 `, {
             order: InputOrder.BYTE_ORDER_BE,
-            parcelSkip: 0
+            bytesSkip: 0
         }).valid).toEqual("valid");
     });
 });

--- a/app/src/kernel/InputParser.ts
+++ b/app/src/kernel/InputParser.ts
@@ -17,14 +17,11 @@ export type InputSettings = {
     order: InputOrder,
 
     /*
-    Команды в RISC-V могут иметь разную длину,
-    но она всегда кратна одному парселю (2 байта, 16 бит).
-    Иногда в начале дампа может быть кусок прошлой команды.
-    Его надо скипнуть.
-    В этом поле указывается неотрицательное количество парселей,
-    которые нужно скипнуть.
+    Количество пропускаемых байт в начале инпута.
+    Изначально планировалось скипать по одному парселю (2 байта),
+    но потом было решено, что нужно скипать байты.
     */
-    parcelSkip: number,
+    bytesSkip: number,
 }
 
 export type ValidInput = {
@@ -65,7 +62,7 @@ export function inputParser(input: string, settings: InputSettings): Input {
         startAddress: 0,
         bytesConcat: "",
     }
-    let notSkippedBytesCount = settings.parcelSkip * 2;
+    let notSkippedBytesCount = settings.bytesSkip;
     let currentAddress = -1;
 
     try {
@@ -84,7 +81,7 @@ export function inputParser(input: string, settings: InputSettings): Input {
                     }
                 }
                 if (result.startAddress === 0) {
-                    result.startAddress = address + settings.parcelSkip;
+                    result.startAddress = address + settings.bytesSkip;
                     if (currentAddress === -1) {
                         currentAddress = result.startAddress
                     } else {
@@ -160,7 +157,6 @@ export function inputParser(input: string, settings: InputSettings): Input {
             message: (error as object).toString()
         }
     }
-    // TODO
     /*
     Преобразует пользовательский инпут в соответствии с настройками.
     Заметки:

--- a/app/src/ui/App.tsx
+++ b/app/src/ui/App.tsx
@@ -210,7 +210,7 @@ const Switch = <T,>(props: {
 const App = () => {
   const [sourceCode, setSourceCode] = useState("");
   const [byteOrder, setByteOrder] = useState(InputOrder.BYTE_ORDER_BE);
-  const [parcelSkip, setParcelSkip] = useState(0);
+  const [bytesSkip, setBytesSkip] = useState(0);
   const [bitDepth, setBitDepth] = useState(BitDepth.BIT_32);
   const [display, setDisplay] = useState<Display>("hex");
   const [jump, setJump] = useState<Jump>("relative");
@@ -225,7 +225,7 @@ const App = () => {
       sourceCode,
       {
         order: byteOrder,
-        parcelSkip: parcelSkip,
+        bytesSkip: bytesSkip,
       },
       {
         bitDepth: bitDepth,
@@ -233,7 +233,7 @@ const App = () => {
     );
     setDisassemblerResult(result);
     console.log(result);
-  }, [sourceCode, byteOrder, parcelSkip, bitDepth]);
+  }, [sourceCode, byteOrder, bytesSkip, bitDepth]);
 
   useEffect(() => {
     const handler = (e: ClipboardEvent) => {
@@ -263,18 +263,18 @@ const App = () => {
           />
         </div>
         <div className="tool">
-          <span>SKIP PARCELS</span>
+          <span>SKIP BYTES</span>
           <input
             type="number"
-            value={parcelSkip}
+            value={bytesSkip}
             onChange={(e) => {
               if (e.currentTarget.value.trim().length === 0) {
-                setParcelSkip(0);
+                setBytesSkip(0);
                 return;
               }
               const value = e.currentTarget.valueAsNumber;
               if (isFinite(value) && value >= 0) {
-                setParcelSkip(value | 0);
+                setBytesSkip(value | 0);
               }
             }}
           />


### PR DESCRIPTION
Также обнаружил ошибку в вычислении startAddress. К нему должно было прибавляться количество байт, а я прибавлял количество парселей. Для наглядности заменил десятичные адреса заменил на шестнадцатиричные